### PR TITLE
Repo Move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# InfraQL has moved to https://github.com/stackql/stackql
+
 <!-- language: lang-none -->
 
 ![Platforms](https://img.shields.io/badge/platform-windows%20macos%20linux-brightgreen)


### PR DESCRIPTION
InfraQL has moved to https://github.com/stackql/stackql, noticed you were a stargazer for InfraQL, StackQL is introducing a whole new architecture which will be more extensible, please give it a ★